### PR TITLE
Fix errant newlines in repr output of SuffixTree.

### DIFF
--- a/suffix_tree.py
+++ b/suffix_tree.py
@@ -103,7 +103,7 @@ class SuffixTree(object):
         for edge in values:
             if edge.source_node_index == -1:
                 continue
-            s += "\t%s \t%s \t%s \t%s \t%s \t\n"%(edge.source_node_index
+            s += "\t%s \t%s \t%s \t%s \t%s \t"%(edge.source_node_index
                     ,edge.dest_node_index 
                     ,self.nodes[edge.dest_node_index].suffix_node 
                     ,edge.first_char_index

--- a/test_suffix_tree.py
+++ b/test_suffix_tree.py
@@ -42,7 +42,8 @@ class SuffixTreeTest(unittest.TestCase):
 
     def test_repr(self):
         st = SuffixTree("t")
-        output = '\tStart \tEnd \tSuf \tFirst \tLast \tString\n\t0 \t1 \t-1 \t0 \t0 \t\nt\n'
+        output = '\tStart \tEnd \tSuf \tFirst \tLast \tString\n\t0 \t1 \t-1 \t0 \t0 \tt\n'
+        import pdb;pdb.set_trace()
         self.assertEqual(st.__repr__(), output)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thanks for the suffix tree! This fixes a little bug in SuffixTree.**repr**. It turns this…

```
>>> t = SuffixTree('outlined')
>>> t
        Start   End     Suf     First   Last    String
        0       3       -1      2       7       
tlined
        0       6       -1      5       7       
ned
        0       2       -1      1       7       
utlined
        0       1       -1      0       7       
outlined
        0       4       -1      3       7       
lined
        0       8       -1      7       7       
d
        0       7       -1      6       7       
ed
        0       5       -1      4       7       
ined
```

…into this:

```
>>> t = SuffixTree('outlined')
>>> t
    Start   End     Suf     First   Last    String
    0       3       -1      2       7       tlined
    0       6       -1      5       7       ned
    0       2       -1      1       7       utlined
    0       1       -1      0       7       outlined
    0       4       -1      3       7       lined
    0       8       -1      7       7       d
    0       7       -1      6       7       ed
    0       5       -1      4       7       ined
```
