### PR TITLE
Fixed __repr__() method of SuffixTree Class

### DIFF
--- a/suffix_tree.py
+++ b/suffix_tree.py
@@ -98,7 +98,7 @@ class SuffixTree(object):
         """
         curr_index = self.N
         s = "\tStart \tEnd \tSuf \tFirst \tLast \tString\n"
-        values = self.edges.values()
+        values = list(self.edges.values())
         values.sort(key=lambda x: x.source_node_index)
         for edge in values:
             if edge.source_node_index == -1:


### PR DESCRIPTION
In python 3.5,  dict.values() returns a view which doesnt have the .sort() method you're calling here. Wrapping it in a list call does the trick.
