### PR TITLE
docs: fix simple typo, contruction -> construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Suffix Trees in Python
 ================================
 
 Based off of Mark Nelson's C++ implementation of Ukkonen's algorithm. Ukkonen's
-algorithm gives a O(n) + O(k) contruction time for a suffix tree, where n is 
+algorithm gives a O(n) + O(k) construction time for a suffix tree, where n is 
 the length of the string and k is the size of the alphabet of that string. 
 Ukkonen's is an online algorithm, processing the input sequentially and producing 
 a valid suffix tree at each character.


### PR DESCRIPTION
There is a small typo in README.md.

Should read `construction` rather than `contruction`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md